### PR TITLE
Fixed add_sleepbout_column.R so that it doesn't fail if no bouts detected

### DIFF
--- a/R/add_sleepbout_column.R
+++ b/R/add_sleepbout_column.R
@@ -10,31 +10,37 @@
 #' @export
 # roxygen2::roxygenise()
 
-add_sleepbout_column = function(ts = c(), sleepBinary = c(), wakeBoutThreshold = 0.3, 
+# define custom add_sleepbout_column (as current one breaks if no bouts detected)
+add_sleepbout_column = function(ts = c(), sleepBinary = c(), wakeBoutThreshold = 0.3,
                                 wakeBoutMin = 10, sleepBoutMin = 180, epochSize = c()) {
-  if (length(epochSize) == 0) {
-    stop("\nArgument epochSize not specified")
-  }
-  if (length(ts) == 0) {
-    stop("\nArgument ts not specified")
-  }
-  sleepBinary = rep(0, nrow(ts))
-  sleepBinary[which(ts$class_id == 0)] = 1
-  bouts = detect_sleepbout(sleepBinary = sleepBinary, wakeBoutThreshold = wakeBoutThreshold, 
+   if (length(epochSize) == 0) {
+      stop("\nArgument epochSize not specified")
+   }
+   if (length(ts) == 0) {
+      stop("\nArgument ts not specified")
+   }
+   sleepBinary = rep(0, nrow(ts))
+   sleepBinary[which(ts$class_id == 0)] = 1
+   bouts = detect_sleepbout(sleepBinary = sleepBinary, wakeBoutThreshold = wakeBoutThreshold,
                               wakeBoutMin = wakeBoutMin, sleepBoutMin = sleepBoutMin, epochSize = epochSize)
-  ts$sleepbouts = 0
-  lastwindow = 0
-  for (j in 1:nrow(bouts)) {
-    if (bouts$state[j] == "sleep") {
-      window = names(sort(-table(ts$window[bouts$start[j]:bouts$end[j]])))[1]
-      if (window != lastwindow) {
-        boutnumber = 1
-        lastwindow = window
-      } else {
-        boutnumber = boutnumber + 1
+   ts$sleepbouts = 0
+   lastwindow = 0
+   # custom fix 1 -> only add information to the column if there is at least one sleep bout identified
+   if(sum(bouts$state=="sleep")>0) {
+      for (j in 1:nrow(bouts)) {
+         if (bouts$state[j] == "sleep") {
+            window = names(sort(-table(ts$window[bouts$start[j]:bouts$end[j]])))[1]
+            # custom fix 2 -> if window=0 and boutnumber is not defined, it breaks the script
+            # so add extra condition to catch if boutnumber not defined
+            if (window != lastwindow | !exists("boutnumber")) {
+               boutnumber = 1
+               lastwindow = window
+            } else {
+               boutnumber = boutnumber + 1
+            }
+            ts$sleepbouts[bouts$start[j]:bouts$end[j]] = boutnumber
+         }
       }
-      ts$sleepbouts[bouts$start[j]:bouts$end[j]] = boutnumber
-    }
-  }
-  return(ts)
+   }
+   return(ts)
 }


### PR DESCRIPTION
Fixes:

- Original script errors if no bouts are detected. I've added catches in the if statements, so that in the case where the `detect_sleepbout` function returns an empty `bouts` data frame, the `for (j in 1:nrow(bouts))` part will not be reached and `ts$sleepbouts` will just contain zeroes.
- There were situations where `if (window != lastwindow)` was false but `boutnumber` had not been defined, causing the script to error out when it reached `boutnumber = boutnumber + 1`. I have since changed `if (window != lastwindow)` to `if ((window != lastwindow) | !exists("boutnumber"))` to catch that case.